### PR TITLE
Fix context lookup bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembodb"
 version = "0.0.1-SNAPSHOT"
-edition = "2024"
+edition = "2021"
 authors = ["Austin Oyugi <austinoyugi@gmail.com>"]
 
 [lib]

--- a/src/memory/context_registry.rs
+++ b/src/memory/context_registry.rs
@@ -42,7 +42,7 @@ pub fn get_from_context_registry(
     match MEMORY_CONTEXT_REGISTRY
         .read()
         .unwrap()
-        .get(&ContextRegistry::TopLevelMemoryContext)
+        .get(&context_name)
     {
         None => {
             trace!("Context {:?} not found", context_name);

--- a/src/storage/layout/tembo_page_tests.rs
+++ b/src/storage/layout/tembo_page_tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::storage::layout::tembo_page::{TemboPage, TemboPageZero};
+    use std::mem::size_of;
 
     #[test]
     fn if_page_zero_size_aligns_with_the_rest_of_the_pages() {


### PR DESCRIPTION
## Summary
- fix context lookup to use given parameter
- import size_of in page tests
- use Rust 2021 edition so tests build

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_688ad587b8c08321b15235c4237ccfae